### PR TITLE
채팅 시작 api 생성, 스레드 로직 구조화 및 리팩토링

### DIFF
--- a/app/model/chatbot_model.py
+++ b/app/model/chatbot_model.py
@@ -28,6 +28,7 @@ def retrieve_assistant():
     except Exception as e:
         return f"Error retrieving assistant: {str(e)}"
 
+
 def start_conversation_with_assistant(assistant):
     try:
         # 새로운 대화 스레드 생성
@@ -61,7 +62,8 @@ def start_conversation_with_assistant(assistant):
     except Exception as e:
         raise Exception(f"Error during conversation: {str(e)}")
 
-def create_conversation_with_assistant(message: str, thread_id):
+
+def create_conversation_with_assistant(message: str, thread_id, assistant_id):
     try:
         # 메세지를 스레드에 추가
         message = client.beta.threads.messages.create(
@@ -72,7 +74,8 @@ def create_conversation_with_assistant(message: str, thread_id):
 
         # assistant와 대화 실행
         run = client.beta.threads.runs.create(
-            thread_id=thread_id
+            thread_id=thread_id,
+            assistant_id=assistant_id
         )
 
         # 대화가 완료될 때까지 상태 확인

--- a/app/model/chatbot_model.py
+++ b/app/model/chatbot_model.py
@@ -13,19 +13,79 @@ load_dotenv()
 # OpenAI API 키 설정
 client = OpenAI(api_key=os.getenv("OPENAI_API_KEY"))
 
-def get_chatbot_response(message: str) -> str:
+
+
+# 벡터 스토어에서 기존 Assistant 불러오기
+def retrieve_assistant():
     try:
-        # OpenAI의 ChatGPT 모델(assistant)을 사용하여 응답 생성
-        response = client.chat.completions.create(
-            messages=[
-                {"role": "system", "content": "You are a helpful assistant."},
-                {"role": "user", "content": message}
-            ],
-            model="gpt-4o"  # 사용할 모델 지정
-        )
-        # API 응답에서 챗봇의 답변만 추출하여 반환
-        return response.choices[0].message.content.strip()
+        # 벡터 스토어에서 기존 Assistant 불러오기
+        vector_store = client.beta.vector_stores.retrieve("vs_wZWpgYaxPipa8tByxs2DSDNk")
+
+        # 기존 assistant를 업데이트 하는 코드
+        assistant = client.beta.assistants.retrieve("asst_JR7zBXnLYraebcyRmKXrKU1o")
+        return vector_store, assistant
 
     except Exception as e:
-        # 오류 발생 시 예외 처리
-        return f"An error occurred: {str(e)}"
+        return f"Error retrieving assistant: {str(e)}"
+
+def start_conversation_with_assistant(assistant):
+    try:
+        # 새로운 대화 스레드 생성
+        thread = client.beta.threads.create(
+            messages=[
+                {
+                    "role": "user",
+                    "content": "'무엇을 도와드릴까요?' 라고만 말해",
+                }
+            ]
+        )
+
+        # assistant와 대화 실행
+        run = client.beta.threads.runs.create(
+            thread_id=thread.id,
+            assistant_id=assistant.id
+        )
+
+        # 대화가 완료될 때까지 상태 확인
+        while run.status != "completed":
+            run = client.beta.threads.runs.retrieve(thread_id=thread.id, run_id=run.id)
+            print(run.status)
+            print(run.completed_at)
+
+            # 대화 완료 후 챗봇 메시지를 출력
+            message = client.beta.threads.messages.list(thread_id=thread.id)
+
+        # "무엇을 도와드릴까요" 반환
+        return message.data[0].content[0].text.value, thread.id
+
+    except Exception as e:
+        raise Exception(f"Error during conversation: {str(e)}")
+
+def create_conversation_with_assistant(message: str, thread_id):
+    try:
+        # 메세지를 스레드에 추가
+        message = client.beta.threads.messages.create(
+            thread_id=thread_id,
+            role="user",
+            content=message
+        )
+
+        # assistant와 대화 실행
+        run = client.beta.threads.runs.create(
+            thread_id=thread_id
+        )
+
+        # 대화가 완료될 때까지 상태 확인
+        while run.status != "completed":
+            run = client.beta.threads.runs.retrieve(thread_id=thread_id, run_id=run.id)
+            print(run.status)
+            print(run.completed_at)
+
+            # 대화 완료 후 챗봇 메시지를 출력
+            message = client.beta.threads.messages.list(thread_id=thread_id)
+
+        # "무엇을 도와드릴까요" 반환
+        return message.data[0].content[0].text.value, thread_id
+
+    except Exception as e:
+        raise Exception(f"Error during conversation: {str(e)}")

--- a/app/routers/chatbot.py
+++ b/app/routers/chatbot.py
@@ -16,6 +16,13 @@ class ChatRequest(BaseModel):
     message: str
 
 
+@router.get("/chatbot/greeting/{user_id}")
+async def greet(user_id: int):
+    user = get_user_by_id(user_id)
+    user_nickname = user["nickname"]
+    response = f"안녕하세요, {user_nickname}님! 어떤 도움이 필요하신가요?"
+    return {"response": response}
+
 @router.post("/chatbot/{user_id}")
 async def chat(user_id: int, request: ChatRequest):
     # 사용자 데이터 가져오기

--- a/app/routers/chatbot.py
+++ b/app/routers/chatbot.py
@@ -1,37 +1,135 @@
-# 요청에 대한 응답 관련 코드
-# FastAPI 라우터와 엔드포인트를 정의해 요청을 처리하고 응답하는 역할
-import openai
+import io
+import os
+
 from fastapi import APIRouter, HTTPException
+import openai
 from pydantic import BaseModel
 
-from app.model.chatbot_model import get_chatbot_response
 from app.rds_dataloader import get_all_burgers
-from app.rds_dataloader.user import get_user_by_id
+from dotenv import load_dotenv
+
+# 환경 변수 로드
+load_dotenv()
 
 router = APIRouter()
+
+# OpenAI 클라이언트 및 벡터 스토어 초기화
+client = openai.OpenAI(api_key=os.getenv("OPENAI_API_KEY"))
 
 
 # 사용자 메세지를 받기 위한 Pydantic 모델 정의
 class ChatRequest(BaseModel):
+    user_id: int
     message: str
 
 
-@router.get("/chatbot/greeting/{user_id}")
-async def greet(user_id: int):
-    user = get_user_by_id(user_id)
-    user_nickname = user["nickname"]
-    response = f"안녕하세요, {user_nickname}님! 어떤 도움이 필요하신가요?"
-    return {"response": response}
+@router.post("/chatbot/")
+async def chat(request: ChatRequest):
+    try:
+        # 사용자 데이터 가져오기
+        user_id, message = request.user_id, request.message
+        print(f"User ID: {user_id}")
+        print(f"Message: {message}")
 
-@router.post("/chatbot/{user_id}")
-async def chat(user_id: int, request: ChatRequest):
-    # 사용자 데이터 가져오기
-    user = get_user_by_id(user_id)
-    burger = get_all_burgers()
+        burger_df = get_all_burgers()
+        burger_df.to_csv("burger_data.txt", index=False)
 
-    # 맞춤형 데이터 구성
-    user_info = (
-        f"사용자 {user['nickname']}에 대한 정보입니다 : "
-        f"맵기 선호도: {user['spicy']}, "
-        f"먹는 양: {user['capacity']}"
+        # RDS에서 받아온 버거 정보를 csv 형태로 변환 후, openai 에서 assistant가 thread에서 사용할 file 로 구성
+        file = client.files.create(
+            file=open("burger_data.txt", "rb"),
+            purpose='assistants'
+        )
+
+        # 사용자 메세지를 포함하는 새로운 대화 스레드 생성
+        thread = client.beta.threads.create(
+            messages=[
+                {
+                    "role": "user",
+                    "content": [
+                        {
+                            "type": "text",
+                            "text": "햄버거 추천해줘"
+                        },
+                    ],
+                }
+            ]
+        )
+
+        # 생성된 스레드와 assistant를 사용해 대화 진행 (어씨스턴트 호출)
+        run = client.beta.threads.runs.create(
+            thread_id=thread.id,
+            assistant_id='asst_JR7zBXnLYraebcyRmKXrKU1o',
+            tools=[{"type": "file_search"}]
+        )
+        print(run)
+
+    except Exception as e:
+        print(f"An error occurred: {e}")
+        raise HTTPException(status_code=500, detail=str(e))
+
+
+if __name__ == "__main__":
+    user_id, message = 1, "햄버거 추천해줘"
+
+    # 벡터 스토어에서 기존 Assistant 불러오기
+    vector_store = client.beta.vector_stores.retrieve("vs_wZWpgYaxPipa8tByxs2DSDNk")
+
+    # 기존 assistant를 업데이트 하는 코드
+    assistant = client.beta.assistants.retrieve("asst_JR7zBXnLYraebcyRmKXrKU1o")
+
+    # 새로운 대화 스레드 생성
+    thread = client.beta.threads.create(
+        messages=[
+            {
+                "role": "user",
+                "content": "'무엇을 도와드릴까요?' 라고만 말해",
+            }
+        ]
     )
+
+    # 메세지를 스레드에 추가
+    message = client.beta.threads.messages.create(
+        thread_id=thread.id,
+        role="user",
+        content=message
+    )
+
+    # assistant와 대화 실행
+    run = client.beta.threads.runs.create(
+        thread_id=thread.id,
+        assistant_id=assistant.id
+    )
+
+    # 대화가 완료될 때까지 상태 확인
+    while run.status != "completed":
+        run = client.beta.threads.runs.retrieve(thread_id=thread.id, run_id=run.id)
+        print(run.status)
+        print(run.completed_at)
+
+    # 대화가 완료되면 메세지를 불러옴
+    message = client.beta.threads.messages.list(thread_id=thread.id)
+    print("챗봇 : ", message.data[0].content[0].text.value)
+
+    # 사용자와의 대화를 반복해서 수행
+    while True:
+        message = input("인간 : ")
+        message = client.beta.threads.messages.create(
+            thread_id=thread.id,
+            role="user",
+            content=message
+        )
+
+        run = client.beta.threads.runs.create(
+            thread_id=thread.id,
+            assistant_id=assistant.id
+        )
+
+        # 대화 완료까지 상태 확인
+        while run.status != "completed":
+            run = client.beta.threads.runs.retrieve(thread_id=thread.id, run_id=run.id)
+            print(run.status)
+            print(run.completed_at)
+
+        # 대화 완료 후 챗봇 메시지를 출력
+        message = client.beta.threads.messages.list(thread_id=thread.id)
+        print(message.data[0].content[0].text.value)

--- a/app/routers/chatbot.py
+++ b/app/routers/chatbot.py
@@ -5,6 +5,8 @@ from fastapi import APIRouter, HTTPException
 import openai
 from pydantic import BaseModel
 
+from app.model.chatbot_model import retrieve_assistant, create_conversation_with_assistant, \
+    start_conversation_with_assistant
 from app.rds_dataloader import get_all_burgers
 from dotenv import load_dotenv
 
@@ -19,117 +21,43 @@ client = openai.OpenAI(api_key=os.getenv("OPENAI_API_KEY"))
 
 # 사용자 메세지를 받기 위한 Pydantic 모델 정의
 class ChatRequest(BaseModel):
-    user_id: int
+    user_email: int
     message: str
+    thread_id: str
 
+# 창이 열리면 불리는 api, 대화 시작 메세지 주면서 스레드 시작 (스레드 id도 전달하기)
+@router.get("/start/")
+async def startchat():
+    try:
+        vector_store, assistant = retrieve_assistant()
+        assistant_reply, thread_id = start_conversation_with_assistant(assistant)
+        # 이 부분은 항상 assistant_reply가 "무엇을 도와들리까요?"이다 -> 이렇게 하는 이유는, 스레드 id로 이어지는 대화를 가능하게 하기 위해
+        return assistant_reply, thread_id
+
+    except Exception as e:
+        print(f"Error starting conversation: {e}")
+        raise HTTPException(status_code=500, detail=str(e))
 
 @router.post("/chatbot/")
 async def chat(request: ChatRequest):
     try:
         # 사용자 데이터 가져오기
-        user_id, message = request.user_id, request.message
-        print(f"User ID: {user_id}")
+        thread_id, user_email, message = request.user_email, request.message, request.thread_id
+        print(f"User Email: {user_email}")
         print(f"Message: {message}")
+        print(f"Thread ID: {thread_id}")
 
         burger_df = get_all_burgers()
         burger_df.to_csv("burger_data.txt", index=False)
 
-        # RDS에서 받아온 버거 정보를 csv 형태로 변환 후, openai 에서 assistant가 thread에서 사용할 file 로 구성
-        file = client.files.create(
-            file=open("burger_data.txt", "rb"),
-            purpose='assistants'
-        )
+        assistant_reply, thread_id = create_conversation_with_assistant(message, thread_id)
 
-        # 사용자 메세지를 포함하는 새로운 대화 스레드 생성
-        thread = client.beta.threads.create(
-            messages=[
-                {
-                    "role": "user",
-                    "content": [
-                        {
-                            "type": "text",
-                            "text": "햄버거 추천해줘"
-                        },
-                    ],
-                }
-            ]
-        )
-
-        # 생성된 스레드와 assistant를 사용해 대화 진행 (어씨스턴트 호출)
-        run = client.beta.threads.runs.create(
-            thread_id=thread.id,
-            assistant_id='asst_JR7zBXnLYraebcyRmKXrKU1o',
-            tools=[{"type": "file_search"}]
-        )
-        print(run)
+        return {"assistant_reply": assistant_reply, "thread_id": thread_id}
 
     except Exception as e:
         print(f"An error occurred: {e}")
         raise HTTPException(status_code=500, detail=str(e))
 
-
-if __name__ == "__main__":
-    user_id, message = 1, "햄버거 추천해줘"
-
-    # 벡터 스토어에서 기존 Assistant 불러오기
-    vector_store = client.beta.vector_stores.retrieve("vs_wZWpgYaxPipa8tByxs2DSDNk")
-
-    # 기존 assistant를 업데이트 하는 코드
-    assistant = client.beta.assistants.retrieve("asst_JR7zBXnLYraebcyRmKXrKU1o")
-
-    # 새로운 대화 스레드 생성
-    thread = client.beta.threads.create(
-        messages=[
-            {
-                "role": "user",
-                "content": "'무엇을 도와드릴까요?' 라고만 말해",
-            }
-        ]
-    )
-
-    # 메세지를 스레드에 추가
-    message = client.beta.threads.messages.create(
-        thread_id=thread.id,
-        role="user",
-        content=message
-    )
-
-    # assistant와 대화 실행
-    run = client.beta.threads.runs.create(
-        thread_id=thread.id,
-        assistant_id=assistant.id
-    )
-
-    # 대화가 완료될 때까지 상태 확인
-    while run.status != "completed":
-        run = client.beta.threads.runs.retrieve(thread_id=thread.id, run_id=run.id)
-        print(run.status)
-        print(run.completed_at)
-
-    # 대화가 완료되면 메세지를 불러옴
-    message = client.beta.threads.messages.list(thread_id=thread.id)
-    print("챗봇 : ", message.data[0].content[0].text.value)
-
-    # 사용자와의 대화를 반복해서 수행
-    while True:
-        message = input("인간 : ")
-        message = client.beta.threads.messages.create(
-            thread_id=thread.id,
-            role="user",
-            content=message
-        )
-
-        run = client.beta.threads.runs.create(
-            thread_id=thread.id,
-            assistant_id=assistant.id
-        )
-
-        # 대화 완료까지 상태 확인
-        while run.status != "completed":
-            run = client.beta.threads.runs.retrieve(thread_id=thread.id, run_id=run.id)
-            print(run.status)
-            print(run.completed_at)
-
-        # 대화 완료 후 챗봇 메시지를 출력
-        message = client.beta.threads.messages.list(thread_id=thread.id)
-        print(message.data[0].content[0].text.value)
+#
+# if __name__ == "__main__":
+#     user_id, message = 1, "햄버거 추천해줘"

--- a/test_main.http
+++ b/test_main.http
@@ -25,6 +25,12 @@ Content-Type: application/json
 }
 
 ###
+# 환영 인사 엔드포인트 테스트
+
+GET http://127.0.0.1:8000/api/chatbot/greeting/1
+Content-Type: application/json
+
+###
 # 챗봇 엔드포인트 테스트
 
 POST http://127.0.0.1:8000/api/chatbot/1

--- a/test_main.http
+++ b/test_main.http
@@ -25,19 +25,18 @@ Content-Type: application/json
 }
 
 ###
-# 환영 인사 엔드포인트 테스트
+# 챗봇 시작 메세지 테스트
 
-GET http://127.0.0.1:8000/api/chatbot/greeting/1
+GET http://127.0.0.1:8000/api/start/
 Content-Type: application/json
 
 ###
-# 챗봇 엔드포인트 테스트
+# 챗봇 대화 테스트
 
-POST http://127.0.0.1:8000/api/chatbot/1
+POST http://127.0.0.1:8000/api/chatbot/
 Content-Type: application/json
 
 {
-  "message": "내 맵기 선호도, 먹는 양을 기반으로 버거 1개만 추천해줘."
+  "user_email": "johyun251602@naver.com",
+  "message": "색다른 버거 추천해줘."
 }
-
-###

--- a/test_main.http
+++ b/test_main.http
@@ -38,5 +38,7 @@ Content-Type: application/json
 
 {
   "user_email": "johyun251602@naver.com",
-  "message": "색다른 버거 추천해줘."
+  "message": "색다른 버거 추천해줘.",
+  "thread_id": "thread_wLiXoatX5Una5ZiHD4A82HHr",
+  "assistant_id": "asst_JR7zBXnLYraebcyRmKXrKU1o"
 }


### PR DESCRIPTION
주요 변경사항입니다.

1. 프론트 쪽에서 요청 주신 user_id 에서 email로의 변경

2. chatbot.py 코드 리팩토링 및 구조화 진행

- @router.get("/start/") 엔드포인트 생성
사용자가 채팅 창을 열 때 호출되는 엔드포인트로, 이 엔드포인트는 환영 메시지 "무엇을 도와드릴까요?"와 함께 스레드 ID를 생성하여 반환합니다. 기존의 @router.post("/chatbot/")는 단일 요청-응답 주기만 처리하는 구조였기 때문에, 지속적인 대화를 이어가고 해당 엔드포인트를 대화에서 재사용하기 위해서는 메시지 요청에 스레드 ID를 함께 보내줘야 했습니다. 따라서 구조적으로 스레드 ID를 대화의 시작 시점에서 생성하고, 이를 환영 메시지와 함께 반환하는 방식으로 구조를 개선하였습니다.
